### PR TITLE
perf: cache the creation of the algorithm

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,29 +224,92 @@ function createNoneVerifier() {
   }
 }
 
-module.exports = function jwa(algorithm) {
-  var signerFactories = {
-    hs: createHmacSigner,
-    rs: createKeySigner,
-    ps: createPSSKeySigner,
-    es: createECDSASigner,
-    none: createNoneSigner,
-  }
-  var verifierFactories = {
-    hs: createHmacVerifier,
-    rs: createKeyVerifier,
-    ps: createPSSKeyVerifier,
-    es: createECDSAVerifer,
-    none: createNoneVerifier,
-  }
-  var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
-  if (!match)
-    throw typeError(MSG_INVALID_ALGORITHM, algorithm);
-  var algo = (match[1] || match[3]).toLowerCase();
-  var bits = match[2];
+var jwaHmac256 = Object.freeze({
+  sign: createHmacSigner('256'),
+  verify: createHmacVerifier('256'),
+});
 
-  return {
-    sign: signerFactories[algo](bits),
-    verify: verifierFactories[algo](bits),
-  }
+var jwaHmac384 = Object.freeze({
+  sign: createHmacSigner('384'),
+  verify: createHmacVerifier('384'),
+});
+
+var jwaHmac512 = Object.freeze({
+  sign: createHmacSigner('512'),
+  verify: createHmacVerifier('512'),
+});
+
+var jwaRsaSha256 = Object.freeze({
+  sign: createKeySigner('256'),
+  verify: createKeyVerifier('256'),
+});
+
+var jwaRsaSha384 = Object.freeze({
+  sign: createKeySigner('384'),
+  verify: createKeyVerifier('384'),
+});
+
+var jwaRsaSha512 = Object.freeze({
+  sign: createKeySigner('512'),
+  verify: createKeyVerifier('512'),
+});
+
+var jwaPssSha256 = Object.freeze({
+  sign: createPSSKeySigner('256'),
+  verify: createPSSKeyVerifier('256'),
+});
+
+var jwaPssSha384 = Object.freeze({
+  sign: createPSSKeySigner('384'),
+  verify: createPSSKeyVerifier('384'),
+});
+
+var jwaPssSha512 = Object.freeze({
+  sign: createPSSKeySigner('512'),
+  verify: createPSSKeyVerifier('512'),
+});
+
+var jwaECDSA256 = Object.freeze({
+  sign: createECDSASigner('256'),
+  verify: createECDSAVerifer('256'),
+});
+
+var jwaECDSA384 = Object.freeze({
+  sign: createECDSASigner('384'),
+  verify: createECDSAVerifer('384'),
+});
+
+var jwaECDSA512 = Object.freeze({
+  sign: createECDSASigner('512'),
+  verify: createECDSAVerifer('512'),
+});
+
+var jwaNone = Object.freeze({
+  sign: createNoneSigner(),
+  verify: createNoneVerifier(),
+});
+
+const algorithmsRecord = {
+  RS256: jwaRsaSha256,
+  RS384: jwaRsaSha384,
+  RS512: jwaRsaSha512,
+  PS256: jwaPssSha256,
+  PS384: jwaPssSha384,
+  PS512: jwaPssSha512,
+  HS256: jwaHmac256,
+  HS384: jwaHmac384,
+  HS512: jwaHmac512,
+  ES256: jwaECDSA256,
+  ES384: jwaECDSA384,
+  ES512: jwaECDSA512,
+  none: jwaNone,
 };
+
+module.exports = function jwa(algorithm) {
+  const algo = algorithmsRecord[algorithm];
+
+  if (!algo) 
+    throw typeError(MSG_INVALID_ALGORITHM, algorithm);
+
+  return algo;
+}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This library is used by [node-jws](https://github.com/auth0/node-jws), every time someone wants to validate a token, they call `jwa` to create the verify function and then discard the object.

> [Code usage reference](https://github.com/auth0/node-jws/blob/b9fb8d30e9c009ade6379f308590f1b0703eefc3/lib/verify-stream.js#L53)

Because of this, I read the code of this library and I found that the object with `sign` and `verify` function is created every call and also runs a `regex` to get the algorithm and the bits.

The current performance is:

```
jwa(RS256) x 5,825,423 ops/sec ±1.12% (92 runs sampled)
jwa(RS384) x 6,216,852 ops/sec ±0.47% (94 runs sampled)
jwa(RS512) x 6,046,150 ops/sec ±1.25% (89 runs sampled)
jwa(PS256) x 4,306,111 ops/sec ±1.14% (93 runs sampled)
jwa(PS384) x 4,260,252 ops/sec ±1.14% (92 runs sampled)
jwa(PS512) x 3,976,296 ops/sec ±4.58% (87 runs sampled)
jwa(HS256) x 4,295,952 ops/sec ±0.87% (93 runs sampled)
jwa(HS384) x 4,225,687 ops/sec ±1.10% (89 runs sampled)
jwa(HS512) x 4,314,741 ops/sec ±1.32% (91 runs sampled)
jwa(ES256) x 4,166,067 ops/sec ±1.03% (89 runs sampled)
jwa(ES384) x 4,157,053 ops/sec ±1.17% (91 runs sampled)
jwa(ES512) x 4,167,795 ops/sec ±0.91% (90 runs sampled)
```

So, instead of creating it every time, I cache the objects with `Object.freeze` to prevent modification, and also use a object with the key being the hashes and the value being the cached objects, now the performance is:

```
jwa(RS256) x 1,044,750,439 ops/sec ±1.77% (90 runs sampled)
jwa(RS384) x 46,073,595 ops/sec ±2.94% (87 runs sampled)
jwa(RS512) x 48,740,542 ops/sec ±2.92% (87 runs sampled)
jwa(PS256) x 50,445,379 ops/sec ±2.11% (85 runs sampled)
jwa(PS384) x 50,930,005 ops/sec ±5.51% (85 runs sampled)
jwa(PS512) x 55,984,858 ops/sec ±1.34% (93 runs sampled)
jwa(HS256) x 59,485,338 ops/sec ±0.88% (93 runs sampled)
jwa(HS384) x 61,521,893 ops/sec ±0.90% (88 runs sampled)
jwa(HS512) x 62,314,092 ops/sec ±2.71% (86 runs sampled)
jwa(ES256) x 42,380,646 ops/sec ±3.55% (61 runs sampled)
jwa(ES384) x 40,491,232 ops/sec ±1.25% (90 runs sampled)
jwa(ES512) x 42,010,686 ops/sec ±1.52% (91 runs sampled)
```

Is an increase in the performance of almost 10x for all cases, also, we reduce to zero the garbage collection by reusing instead of allocating.

<details>
<summary>More about memory usage</summary>

> I'm using [isitfast](https://github.com/yamiteru/isitfast), ignore the op/s which is not currently stable.

Before:

```
jwa(RS512) 1,845,018 op/s (542 ns) ±1% x2,500 | 248 kB ±2% x25
jwa(RS384) 6,211,180 op/s (161 ns) ±1% x2,500 | 232 kB ±2% x25
jwa(RS256) 12,345,679 op/s (81 ns) ±1% x2,500 | 232 kB ±2% x25
jwa(PS512) 1,173,709 op/s (852 ns) ±1% x2,500 | 360 kB ±1% x25
jwa(PS384) 4,524,887 op/s (221 ns) ±1% x2,500 | 360 kB ±1% x25
jwa(PS256) 2,314,815 op/s (432 ns) ±1% x2,500 | 360 kB ±1% x25
jwa(HS512) 4,761,905 op/s (210 ns) ±1% x2,500 | 360 kB ±1% x25
jwa(HS384) 2,169,197 op/s (461 ns) ±1% x2,500 | 360 kB ±1% x25
jwa(HS256) 6,211,180 op/s (161 ns) ±1% x2,500 | 320 kB ±2% x25
jwa(ES512) 5,000,000 op/s (200 ns) ±1% x2,500 | 544 kB ±0.9% x25
jwa(ES384) 4,975,124 op/s (201 ns) ±1% x2,500 | 544 kB ±0.9% x25
jwa(ES256) 6,211,180 op/s (161 ns) ±1% x2,500 | 544 kB ±0.9% x25
```

Now:

```
jwa(RS512) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(RS384) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(RS256) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(PS512) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(PS384) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(PS256) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(HS512) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(HS384) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(HS256) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(ES512) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(ES384) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
jwa(ES256) ∞ op/s (0 ns) ±0% x2,500 | 0 kB ±0% x25
```

</details>

The RS256 with 1B op/s probably is caused by optimization of v8 bail-out after discovering the function could receive values other than RS256.

### Testing

I didn't change the behavior, I only introduce a cache and freeze of the objects.

`Object.freeze` was introduced on NodeJS v0.10.0, so I don't think we will have some compatibility issues.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
