### PR TITLE
Replace `buffer-equal-constant-time` with `crypto.timingSafeEqual`

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,13 +134,25 @@ function createHmacSigner(bits) {
   }
 }
 
+var bufferEqual;
+var timingSafeEqual = 'timingSafeEqual' in crypto ? function timingSafeEqual(a, b) {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(a, b)
+} : function timingSafeEqual(a, b) {
+  if (!bufferEqual) {
+    bufferEqual = require('buffer-equal-constant-time');
+  }
+
+  return bufferEqual(a, b)
+}
+
 function createHmacVerifier(bits) {
   return function verify(thing, signature, secret) {
     var computedSig = createHmacSigner(bits)(thing, secret);
-    if (signature.length !== computedSig.length) {
-      return false;
-    }
-    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(computedSig));
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(computedSig));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var bufferEqual = require('buffer-equal-constant-time');
 var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
 var formatEcdsa = require('ecdsa-sig-formatter');
@@ -138,7 +137,10 @@ function createHmacSigner(bits) {
 function createHmacVerifier(bits) {
   return function verify(thing, signature, secret) {
     var computedSig = createHmacSigner(bits)(thing, secret);
-    return bufferEqual(Buffer.from(signature), Buffer.from(computedSig));
+    if (signature.length !== computedSig.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(computedSig));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "test"
   },
   "dependencies": {
-    "buffer-equal-constant-time": "1.0.1",
     "ecdsa-sig-formatter": "1.0.11",
     "safe-buffer": "^5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "buffer-equal-constant-time": "^1.0.1",
     "ecdsa-sig-formatter": "1.0.11",
     "safe-buffer": "^5.0.1"
   },


### PR DESCRIPTION
buffer-equal-constant-time uses SlowBuffer that has been removed on Node 24

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This pull request addresses a compatibility issue with Node 24 by replacing the buffer-equal-constant-time package with the native crypto.timingSafeEqual method. buffer-equal-constant-time relies on SlowBuffer and has been removed on Node 24, causing this library to crash.

### References
Fixes:
- #51 
- https://github.com/auth0/node-jsonwebtoken/issues/992

### Testing

This PR doesn't change the code behavior and passed all tests.
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
